### PR TITLE
[fetch] Use fetch api for requests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,13 @@
     "mocha": "^3.2.0",
     "mocha-circleci-reporter": "0.0.2",
     "npm-build-tools": "^2.2.5",
+    "null-loader": "^0.1.1",
     "webpack": "^1.12.13"
   },
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "compact-base64": "^1.1.0",
-    "xhr2": "^0.1.3"
+    "node-fetch": "^1.6.3",
+    "unfetch": "^2.1.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,10 @@ module.exports = {
             test: /\.js$/,
             exclude: path.resolve(__dirname, 'node_modules'),
             loader: 'babel'
+        },
+        {
+            test: /node-fetch/,
+            loader: 'null'
         }]
     },
 


### PR DESCRIPTION
Allows us to take advantage of packages like `fetch-retried` and `fetch-queued`.
This will use `unfetch` when running in the browser.